### PR TITLE
Fixed PHP5+ and SQL query for PHP server

### DIFF
--- a/servers/crashdumpbrowser/includes/db.inc.php
+++ b/servers/crashdumpbrowser/includes/db.inc.php
@@ -78,7 +78,7 @@ class db {
                   $clause = $table .".`$col` IN (";
                   $array = array();
                   foreach($val as &$v) {
-                     $array[] = "?";
+                     $array[] = strval($v);
                      if (is_numeric($v)) {
                         $types .= "i";
                      } else {
@@ -161,7 +161,7 @@ class db {
       $params[] = &$perPage;
       $params[0] = &$types;
       if ($stmt = self::$mysqli->prepare($sql)) {
-         call_user_func_array(array($stmt, "bind_param"), &$params);
+         call_user_func_array(array($stmt, "bind_param"), $params);
          return self::query($stmt);
       } else {
          throw new Exception(self::$mysqli->error);
@@ -334,14 +334,14 @@ class db {
       } else {
          $sql .= " ORDER BY lastTime DESC";
       }
-      $sql .= " LIMIT ?, ?";
       $start = $page * $perPage;
+      $sql .= " LIMIT ".strval($start).", ".strval($perPage);
       $params[] = &$start;
       $params[] = &$perPage;
       $types .= "ii";
       $params[0] = &$types;
       if ($stmt = self::$mysqli->prepare($sql)) {
-         call_user_func_array(array($stmt, "bind_param"), &$params);
+         call_user_func_array(array($stmt, "bind_param"), $params);
          return self::query($stmt);
       } else {
          throw new Exception(self::$mysqli->error);


### PR DESCRIPTION
- PHP5.4 removed call-time pass-by-reference;
- SQL query were formed invalid, not generating proper `LIMIT` and `Status` filters;

Additional notes:
- `openfl.utils.SystemPath` removed in OFL4 and raise compilation error, additional `#if` required.
- PHP server expects `game id` parameter, which is not possible to send without extending `CrashDumper` instance. Current workaround is to use `filename` as game id, by changing  [`ERROR_PROJECTNAME` constant](https://github.com/larsiusprime/crashdumper/blob/d49565fac30ac84b394e73b6119a5002f2e765c2/servers/crashdumpbrowser/includes/constants.inc.php#L18)
